### PR TITLE
MindSpore: Avoid using model input and output names

### DIFF
--- a/examples/project/mnist-mindspore/src/flowunit/mnist_infer/mnist_infer.toml
+++ b/examples/project/mnist-mindspore/src/flowunit/mnist_infer/mnist_infer.toml
@@ -24,10 +24,10 @@ virtual_type = "mindspore"
 
 [input]
 [input.input1] 
-name = "x" 
+name = "input" 
 type = "float" 
 
 [output]
 [output.output1] 
-name = "Default/fc3-Dense/BiasAdd-op229" 
+name = "output" 
 type = "float"

--- a/examples/project/mnist-mindspore/src/flowunit/mnist_infer/train.sh
+++ b/examples/project/mnist-mindspore/src/flowunit/mnist_infer/train.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language 
 
 CURRDIR=$(pwd)
-VERSION="1.6.1"
+VERSION="1.7.0"
 TRAIN_VER="r1.6"
 
 get_package_archname() {

--- a/examples/project/mnist-mindspore/src/graph/mnist.toml
+++ b/examples/project/mnist-mindspore/src/graph/mnist.toml
@@ -18,8 +18,8 @@ graphconf = '''digraph mnist_sample {
     httpserver_sync_reply[type=flowunit, flowunit=httpserver_sync_reply, device=cpu]
 
     httpserver_sync_receive:out_request_info -> mnist_preprocess:in_data
-    mnist_preprocess:out_data -> mnist_infer:x
-    mnist_infer:"Default/fc3-Dense/BiasAdd-op229" -> mnist_response:in_data
+    mnist_preprocess:out_data -> mnist_infer:input
+    mnist_infer:output -> mnist_response:in_data
     mnist_response:out_data -> httpserver_sync_reply:in_reply_info
 }
 '''

--- a/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/mindspore_cpu_inference_flowunit_test.cc
+++ b/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/mindspore_cpu_inference_flowunit_test.cc
@@ -94,9 +94,9 @@ TEST_F(InferenceMindSporeCPUFlowUnitTest, RunUnit) {
           mindspore_inference[type=flowunit, flowunit=mindspore_inference, device=cpu, deviceid=0, batch_size=2]
           check_ms_infer_result[type=flowunit, flowunit=check_ms_infer_result, device=cpu, deviceid=0, batch_size=2]  
                                   
-          prepare_ms_infer_data:out1 -> mindspore_inference:x_
-          prepare_ms_infer_data:out2 -> mindspore_inference:y_
-          mindspore_inference:"Default/Add-op3"-> check_ms_infer_result:in
+          prepare_ms_infer_data:out1 -> mindspore_inference:input1
+          prepare_ms_infer_data:out2 -> mindspore_inference:input2
+          mindspore_inference:output1 -> check_ms_infer_result:in
         }'''
     format = "graphviz"
   )";
@@ -116,9 +116,9 @@ TEST_F(InferenceMindSporeCPUFlowUnitTest, RunUnitEncrypt) {
           mindspore_inference[type=flowunit, flowunit=mindspore_inference_encrypt, device=cpu, deviceid=0, batch_size=2]
           check_ms_infer_result[type=flowunit, flowunit=check_ms_infer_result, device=cpu, deviceid=0, batch_size=2]  
                                   
-          prepare_ms_infer_data:out1 -> mindspore_inference:x_
-          prepare_ms_infer_data:out2 -> mindspore_inference:y_
-          mindspore_inference:"Default/Add-op3" -> check_ms_infer_result:in
+          prepare_ms_infer_data:out1 -> mindspore_inference:input1
+          prepare_ms_infer_data:out2 -> mindspore_inference:input2
+          mindspore_inference:output1 -> check_ms_infer_result:in
         }'''
     format = "graphviz"
   )";

--- a/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/test_toml/modelbox.test.mindspore.cpu.inference.encrypt.in
+++ b/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/test_toml/modelbox.test.mindspore.cpu.inference.encrypt.in
@@ -15,16 +15,16 @@ passwd = "ToT+qoCsXk6r49CowwSVM2rqJmU0y279CIlnqzaBfRdMbYaYF5lp2pwhbiZ4/L5lhr4LJu
 
 [input]
 [input.input1]
-name = "x_"
+name = "input1"
 type = "float"
 device = "cpu"
 
 [input.input2]
-name = "y_"
+name = "input2"
 type = "float"
 device = "cpu"
 
 [output]
 [output.output1]
-name = "Default/Add-op3"
+name = "output1"
 type = "float"

--- a/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/test_toml/modelbox.test.mindspore.cpu.inference.in
+++ b/src/drivers/devices/cpu/flowunit/mindspore_lite_inference/test_toml/modelbox.test.mindspore.cpu.inference.in
@@ -12,16 +12,16 @@ input_format = "NCHW"
 
 [input]
 [input.input1]
-name = "x_"
+name = "input1"
 type = "float"
 device = "cpu"
 
 [input.input2]
-name = "y_"
+name = "input2"
 type = "float"
 device = "cpu"
 
 [output]
 [output.output1]
-name = "Default/Add-op3"
+name = "output1"
 type = "float"

--- a/src/drivers/inference_engine/mindspore/mindspore_inference.h
+++ b/src/drivers/inference_engine/mindspore/mindspore_inference.h
@@ -53,6 +53,7 @@ class MindSporeInference {
   std::shared_ptr<mindspore::Model> model_{nullptr};
   std::shared_ptr<mindspore::Context> context_{nullptr};
   int64_t batch_size_{0};
+  struct MindSporeIOList io_list_;
 };
 
 #endif

--- a/src/modelbox/manager/etc/init.d/modelbox-manager.in
+++ b/src/modelbox/manager/etc/init.d/modelbox-manager.in
@@ -87,7 +87,7 @@ case $1 in
 
 		kill -TERM "$PID"
 		if [ $? -ne 0 ]; then
-			echo "Stop modelbox-manager service failed."
+			echo "stop modelbox-manager service failed."
 			exit 1;
 		fi
 
@@ -105,7 +105,7 @@ case $1 in
 			sleep .5
 		done
 		rm -f "$PIDFILE"
-		echo "Stop modelbox-manager service success."
+		echo "stop modelbox-manager service success."
 		;;
 	restart)
 		"$0" stop && sleep 1 && "$0" start

--- a/src/modelbox/server/bin/develop
+++ b/src/modelbox/server/bin/develop
@@ -311,7 +311,7 @@ showhelp() {
     echo " -h            show this help message."
     echo ""
     echo "addition options"
-    echo " --home        home directory, default is \$HOME/modelbox"
+    echo " --home        home directory, default is \$HOME/modelbox-service"
 }
 
 main() {

--- a/src/modelbox/server/etc/init.d/modelbox.in
+++ b/src/modelbox/server/etc/init.d/modelbox.in
@@ -86,7 +86,7 @@ case $1 in
 
 		kill -TERM "$PID"
 		if [ $? -ne 0 ]; then
-			echo "Stop modelbox service failed."
+			echo "stop modelbox service failed."
 			exit 1;
 		fi
 
@@ -103,7 +103,7 @@ case $1 in
 			LOOP=$((LOOP+1))
 			sleep .5
 		done
-		echo "Stop modelbox service success."
+		echo "stop modelbox service success."
 		;;
 	restart)
 		"$0" stop && sleep 1 && "$0" start


### PR DESCRIPTION
避免将mindspore的模输入，输出名称绑定。用序号关联模型端口