### PR TITLE
Fixed when meta transfers an empty array, out-of-bounds array

### DIFF
--- a/src/drivers/common/python/modelbox_api/modelbox_api.cc
+++ b/src/drivers/common/python/modelbox_api/modelbox_api.cc
@@ -152,9 +152,12 @@ bool SetAttributes(DataType &context, const std::string &key,
 
   if (py::isinstance<py::list>(obj)) {
     py::list obj_list_all = obj.cast<py::list>();
+    if (obj_list_all.empty()) {
+      return setup_data(List1DObjectFunc, obj_list_all, obj_list_all);
+    }
     if (py::isinstance<py::list>(obj_list_all[0])) {
       py::list obj_list_1d = obj_list_all[0].cast<py::list>();
-      if (setup_data(List2DObjectFunc, obj_list_1d[0], obj_list_all)) {
+      if (setup_data(List2DObjectFunc, obj_list_1d.empty() ? obj_list_1d : obj_list_1d[0], obj_list_all)) {
         return true;
       }
     } else {


### PR DESCRIPTION
Fixed the problem when meta transfers an empty array, out-of-bounds array